### PR TITLE
Fix year parsing from hebrew

### DIFF
--- a/common.js
+++ b/common.js
@@ -106,7 +106,7 @@ exports.monthNum = function(month) {
 
 exports.dayYearNum = function(str) {
 	return typeof str === 'number' ? str :
-		str[charCodeAt](0) >= 1488 && str[charCodeAt](0) <= 1514 ? gematriya(str) : parseInt(str, 10);
+		str[charCodeAt](0) >= 1488 && str[charCodeAt](0) <= 1514 ? gematriya(str, 5) : parseInt(str, 10);
 };
 
 /* Days from sunday prior to start of Hebrew calendar to mean


### PR DESCRIPTION
Five-letter years in Hebrew yielded a wrong date: `hebcal.HDate('ל' אב התשע"ג')`
Fixed by passing limit of 5 to gematriya to prevent string clipping