### PR TITLE
Update dependencies versions for node v8 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
 		"build": "node compile.js"
 	},
 	"dependencies": {
-		"suncalc": "",
-		"gematriya": ""
+		"suncalc": "^1.8.0",
+		"gematriya": "^1.0.1"
 	},
 	"devDependencies": {
 		"browserify": "^14.0.0",


### PR DESCRIPTION
The module not working on node v8 (Error: Cannot find module 'gematriya'/'suncalc')